### PR TITLE
Fix version of k8s.io/client-go from v12.0.0+incompatible to v0.27.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/api v0.27.1
 	k8s.io/apiextensions-apiserver v0.26.3
 	k8s.io/apimachinery v0.27.1
-	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/client-go v0.27.1
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	kubevirt.io/api v0.0.0-20230729091846-11376fe9005b


### PR DESCRIPTION
Fixes #28 