### PR TITLE
done in StreamInterface

### DIFF
--- a/kubecli/kubevirt.go
+++ b/kubecli/kubevirt.go
@@ -241,6 +241,7 @@ type StreamOptions struct {
 type StreamInterface interface {
 	Stream(options StreamOptions) error
 	AsConn() net.Conn
+	Done()
 }
 
 type VirtualMachineInstanceInterface interface {

--- a/kubecli/streamer.go
+++ b/kubecli/streamer.go
@@ -9,11 +9,16 @@ import (
 
 type wsStreamer struct {
 	conn *websocket.Conn
-	done chan struct{}
+
+	done   chan struct{}
+	isDone bool
 }
 
-func (ws *wsStreamer) streamDone() {
-	close(ws.done)
+func (ws *wsStreamer) Done() {
+	if !ws.isDone {
+		close(ws.done)
+		ws.isDone = true
+	}
 }
 
 func (ws *wsStreamer) Stream(options StreamOptions) error {
@@ -29,7 +34,7 @@ func (ws *wsStreamer) Stream(options StreamOptions) error {
 		copyErr <- err
 	}()
 
-	defer ws.streamDone()
+	defer ws.Done()
 	return <-copyErr
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`wsStreamer` is used in two different ways, by calling `Stream` and by calling `AsConn`. When `AsConn` is used, the stream's done channel is not properly closed. E.g: while doing ssh.PrepareSSHClient.

This PR allows users of the StreamInterface to signal the stream as done when using `AsConn` in all those cases where the `done` channel cannot be controlled directly which is a very needed thing for things like `asyncSubresourceHelper` to work without substantiatlly changing the VM and VMI interfaces for things like [port forward
](https://github.com/kubevirt/client-go/blob/main/kubecli/vm.go#L238).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Didn't open an issue, sorry!

**Special notes for your reviewer**:
I have a branch on kubevirt based on this. If this gets in I'll send another PR to use the streamer interface as it is changed here and to update the deps.

https://github.com/fntlnz/kubevirt/commits/lf/close-streams-native-client/

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:

```release-note

```
